### PR TITLE
Metrics server apply - Updated to reference kubelet use-node-status-port

### DIFF
--- a/scripts/functions/image/ensure-metrics-server.sh
+++ b/scripts/functions/image/ensure-metrics-server.sh
@@ -20,6 +20,7 @@ ensure_metrics_server() {
           "--secure-port=4443",
           "--kubelet-insecure-tls",
           "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+          "--kubelet-use-node-status-port",
           "--metric-resolution=15s"
         ]
       }


### PR DESCRIPTION
Metrics server apply - Updated to reference kubelet use-node-status-port