### PR TITLE
Provison worker vm macos - Updated release version to 24.04.4

### DIFF
--- a/scripts/worker/provision-worker-vm.sh
+++ b/scripts/worker/provision-worker-vm.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # ============================================================================
 
 # === CONFIG ===
-ISO_ORIG="ubuntu-24.04-live-server-arm64.iso"
+ISO_ORIG="ubuntu-24.04.4-live-server-arm64.iso"
 ISO_CUSTOM="ubuntu-autoinstall.iso"
 # Minimum expected ISO size: 1 GB
 ISO_MIN_BYTES=1073741824
@@ -45,7 +45,7 @@ if [ "$ISO_SIZE" -lt "$ISO_MIN_BYTES" ]; then
   echo "ISO missing or too small (${ISO_SIZE} bytes) — downloading Ubuntu ARM ISO..."
   rm -f "$ISO_ORIG"
   curl -L --fail -o "$ISO_ORIG" \
-    https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-arm64.iso
+    https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04.4-live-server-arm64.iso
   ISO_SIZE=$(stat -c%s "$ISO_ORIG")
   if [ "$ISO_SIZE" -lt "$ISO_MIN_BYTES" ]; then
     echo "ERROR: ISO download failed or incomplete (${ISO_SIZE} bytes)."


### PR DESCRIPTION
Provison worker vm macos - Updated release version to 24.04.4